### PR TITLE
fix: parse translations with labels correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2022-04-03
+
+### Bug Fixes
+
+- [**breaking**] Parse translations with labels correctly
+
+### Documentation
+
+- Update CHANGELOG.md for v0.4.0
+
 ## [0.3.0] - 2022-03-20
 
 ### Bug Fixes

--- a/data/edit_translation.json
+++ b/data/edit_translation.json
@@ -2,7 +2,13 @@
     "data": {
         "termId": "7eafe83d-1448-49ea-8ae0-f8753cbd669c",
         "value": "New translation",
-        "labels": ["somelabel"],
+        "labels": [
+            {
+                "id": "c16d0fc3-73e6-4962-b8d5-f3054b8ff002",
+                "value": "Example label",
+                "color": "#D81159"
+            }
+        ],
         "date": {
             "created": "2021-10-25T18:54:16.422Z",
             "modified": "2021-10-26T16:03:09.000Z"

--- a/data/translations.json
+++ b/data/translations.json
@@ -3,7 +3,13 @@
         {
             "termId": "38ba819e-8023-464b-aa1b-6177c149f888",
             "value": "My first translation",
-            "labels": ["somelabel"],
+            "labels": [
+                {
+                    "id": "c16d0fc3-73e6-4962-b8d5-f3054b8ff002",
+                    "value": "Example label",
+                    "color": "#D81159"
+                }
+            ],
             "date": {
                 "created": "2021-10-25T18:54:16.426Z",
                 "modified": "2021-10-25T18:54:16.426Z"

--- a/src/api/translations/common.rs
+++ b/src/api/translations/common.rs
@@ -16,7 +16,7 @@ pub struct Translation {
     /// The translation of the term.
     pub value: String,
     /// Labels the term is tagged with.
-    pub labels: Vec<String>,
+    pub labels: Vec<api::labels::Label>,
     /// Timestamp about creation and last modification
     /// of this translation.
     pub date: api::AccessDates,

--- a/src/api/translations/edit.rs
+++ b/src/api/translations/edit.rs
@@ -19,7 +19,7 @@ use crate::{
 /// ```
 /// # use traduora::{Login, TestClient as Traduora, TraduoraError};
 /// use chrono::{TimeZone, Utc};
-/// use traduora::{api::{translations::EditTranslation, Role}, Query};
+/// use traduora::{api::{translations::EditTranslation, Role, labels::Label}, Query};
 ///
 /// # let login = Login::password("tester@mail.example", "letmeinpls");
 /// let client = Traduora::with_auth("localhost:8080", login)?;
@@ -30,7 +30,14 @@ use crate::{
 /// let translation = endpoint.query(&client)?;
 ///
 /// assert_eq!(translation.value, "New translation");
-/// assert_eq!(translation.labels, vec!["somelabel"]);
+/// assert_eq!(
+///     translation.labels,
+///     vec![Label {
+///         id: "c16d0fc3-73e6-4962-b8d5-f3054b8ff002".into(),
+///         value: "Example label".into(),
+///         color: "#D81159".into()
+///     }]
+/// );
 /// assert_eq!(translation.term_id.value(), "7eafe83d-1448-49ea-8ae0-f8753cbd669c");
 /// assert_eq!(translation.date.created, Utc.ymd(2021, 10, 25).and_hms_milli(18, 54, 16, 422));
 /// assert_eq!(translation.date.modified, Utc.ymd(2021, 10, 26).and_hms_milli(16, 03, 09, 000));

--- a/src/api/translations/list.rs
+++ b/src/api/translations/list.rs
@@ -18,7 +18,7 @@ use crate::{
 /// ```
 /// # use traduora::{Login, TestClient as Traduora, TraduoraError};
 /// use chrono::{TimeZone, Utc};
-/// use traduora::{api::translations::Translations, Query};
+/// use traduora::{api::translations::Translations, api::labels::Label, Query};
 ///
 /// # let login = Login::password("tester@mail.example", "letmeinpls");
 /// let client = Traduora::with_auth("localhost:8080", login)?;
@@ -28,7 +28,14 @@ use crate::{
 ///
 /// assert_eq!(translations.len(), 2);
 /// assert_eq!(translations[0].value, "My first translation");
-/// assert_eq!(translations[0].labels, vec!["somelabel"]);
+/// assert_eq!(
+///     translations[0].labels,
+///     vec![Label {
+///         id: "c16d0fc3-73e6-4962-b8d5-f3054b8ff002".into(),
+///         value: "Example label".into(),
+///         color: "#D81159".into()
+///     }]
+/// );
 /// assert_eq!(translations[0].term_id.value(), "38ba819e-8023-464b-aa1b-6177c149f888");
 /// assert_eq!(translations[0].date.created, Utc.ymd(2021, 10, 25).and_hms_milli(18, 54, 16, 426));
 /// assert_eq!(translations[0].date.modified, Utc.ymd(2021, 10, 25).and_hms_milli(18, 54, 16, 426));


### PR DESCRIPTION
Fixes #6 Translation with labels fail to parse

API documentation says that `Translation` contains an array of strings for
field `labels` but it's actually an array of `ProjectLabelDTO`s.

BREAKING CHANGE: `Translation.labels` is now `Vec<Label>` instead of
`Vec<String>`.